### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ brew install zsh
 curl -L https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh | sh
 
 # Clone this repository
-git clone git@github.com:itsthatguy/itg.zsh-theme.git
+git clone https://github.com/itsthatguy/itg.zsh-theme.git
 cd itg.zsh-theme
 
 # Run the install script


### PR DESCRIPTION
The previous `git clone` command had the SSH address, so people not authorized could not clone it. 

Changing it to `https` - just like the `oh-my-zsh` from above seems more user-friendly.